### PR TITLE
Activityの新規作成APIの実装

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -7,4 +7,14 @@ class Api::ActivitiesController < Api::ApplicationController
     activities = Activity.includes(:store).includes(:menu).where(user_id: current_user.id)
     render json: activities
   end
+
+  def create
+    payload = ActivityPayload::Create.new(params, current_user.id)
+    if payload.valid?
+      activity = Activity.create!(payload.to_h)
+      render json: activity
+    else
+      render_422(payload.errors)
+    end
+  end
 end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -4,4 +4,8 @@ class Api::ApplicationController < ApplicationController
   def check_login
     return render json: {}, status: :unauthorized unless is_login?
   end
+
+  def render_422(errors = "Unprocessable Entity")
+    render json: { errors: errors }, status: :unprocessable_entity
+  end
 end

--- a/app/payloads/activity_payload/create.rb
+++ b/app/payloads/activity_payload/create.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class ActivityPayload::Create
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :userId, :integer
+  attribute :storeId, :integer
+  attribute :menuId, :integer
+  attribute :size, :string
+  attribute :yasai, :string
+  attribute :ninniku, :string
+  attribute :abura, :string
+  attribute :karame, :string
+  attribute :calorie, :integer
+  attribute :imageUrl, :string
+
+  validates :userId, presence: true
+  validates :storeId, presence: true
+  validates :menuId, presence: true
+  validates :calorie, presence: true
+  validates :imageUrl, presence: true
+  validates :size, presence: true, inclusion: {
+    in: ["small", "large"]
+  }
+  validates :yasai, presence: true, inclusion: {
+    in: ["small", "normal", "large", "mashimashi"]
+  }
+  validates :ninniku, presence: true, inclusion: {
+    in: ["small", "normal", "large", "mashimashi"]
+  }
+  validates :abura, presence: true, inclusion: {
+    in: ["small", "normal", "large", "mashimashi", "crazy"]
+  }
+  validates :karame, presence: true, inclusion: {
+    in: ["small", "normal", "large", "mashimashi"]
+  }
+
+  def initialize(params, user_id)
+    p = params.permit(
+      :storeId,
+      :menuId,
+      :size,
+      :yasai,
+      :ninniku,
+      :abura,
+      :karame,
+      :calorie,
+      :imageUrl,
+    )
+    p[:userId] = user_id
+    super(p)
+  end
+
+  def to_h
+    {
+      user_id: self.userId,
+      store_id: self.storeId,
+      menu_id: self.menuId,
+      size: self.size,
+      yasai: self.yasai,
+      ninniku: self.ninniku,
+      abura: self.abura,
+      karame: self.karame,
+      calorie: self.calorie,
+      image_url: self.imageUrl,
+    }
+  end
+end

--- a/app/serializers/api/activity_serializer.rb
+++ b/app/serializers/api/activity_serializer.rb
@@ -7,19 +7,31 @@ class Api::ActivitySerializer < ActiveModel::Serializer
   attributes :ninniku
   attributes :abura
   attributes :karame
-  attributes :image_url
   attributes :calorie
-  attributes :created_at
-  attributes :updated_at
 
-  attributes :store_name
-  attributes :menu_name
+  attributes :storeName
+  attributes :menuName
+  attributes :imageUrl
+  attributes :createdAt
+  attributes :updatedAt
 
-  def store_name
+  def storeName
     object.store.name
   end
 
-  def menu_name
+  def menuName
     object.menu.name
+  end
+
+  def imageUrl
+    object.image_url
+  end
+
+  def createdAt
+    object.created_at
+  end
+
+  def updatedAt
+    object.updated_at
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get "/auth/google/callback", to: "sessions#callback"
 
   namespace :api do
-    resources :activities, only: [:index]
+    resources :activities, only: [:index, :create]
   end
 
   root to: "dashboard#index"

--- a/db/migrate/20190628112048_add_options_to_activies.rb
+++ b/db/migrate/20190628112048_add_options_to_activies.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddOptionsToActivies < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :activities, :image_url, false, ""
+    change_column :activities, :image_url, :string, default: ""
+
+    change_column_null :activities, :calorie, false, 0
+    change_column :activities, :calorie, :integer, default: 0
+  end
+
+  def down
+    change_column_null :activities, :image_url, true, nil
+    change_column :activities, :image_url, :string, default: nil
+
+    change_column_null :activities, :calorie, true, nil
+    change_column :activities, :calorie, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_180_610_013_844) do
+ActiveRecord::Schema.define(version: 2019_06_28_112048) do
+
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "store_id", null: false
@@ -22,8 +23,8 @@ ActiveRecord::Schema.define(version: 20_180_610_013_844) do
     t.string "ninniku", null: false
     t.string "abura", null: false
     t.string "karame", null: false
-    t.string "image_url"
-    t.integer "calorie"
+    t.string "image_url", default: "", null: false
+    t.integer "calorie", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_activities_on_user_id"
@@ -48,4 +49,5 @@ ActiveRecord::Schema.define(version: 20_180_610_013_844) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     ninniku { "small" }
     abura { "normal" }
     karame { "small" }
-    image_url { nil }
-    calorie { nil }
+    image_url { "http://test.image.url/1234.jpeg" }
+    calorie { 1234 }
   end
 end

--- a/spec/payloads/activity_payload/create_spec.rb
+++ b/spec/payloads/activity_payload/create_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ActivityPayload::Create, type: :model do
+  describe "validation" do
+    let(:params) {
+      ActionController::Parameters.new({
+        storeId: 2,
+        menuId: 3,
+        size: "normal",
+        yasai: "normal",
+        ninniku: "normal",
+        abura: "normal",
+        karame: "normal",
+        calorie: 1234,
+        imageUrl: "http://test.image.path/12345.png",
+      })
+    }
+    let(:user_id) { 1 }
+
+    subject { ActivityPayload::Create.new(params, user_id) }
+
+    it { should validate_presence_of(:userId) }
+    it { is_expected.to validate_presence_of(:storeId) }
+    it { is_expected.to validate_presence_of(:menuId) }
+    it { is_expected.to validate_presence_of(:size) }
+    it { is_expected.to validate_presence_of(:yasai) }
+    it { is_expected.to validate_presence_of(:ninniku) }
+    it { is_expected.to validate_presence_of(:abura) }
+    it { is_expected.to validate_presence_of(:karame) }
+    it { is_expected.to validate_presence_of(:calorie) }
+    it { is_expected.to validate_presence_of(:imageUrl) }
+
+    it do
+      is_expected.to validate_inclusion_of(:size).
+        in_array(["small", "large"])
+    end
+
+    it do
+      is_expected.to validate_inclusion_of(:yasai).
+        in_array(["small", "normal", "large", "mashimashi"])
+    end
+
+    it do
+      is_expected.to validate_inclusion_of(:ninniku).
+        in_array(["small", "normal", "large", "mashimashi"])
+    end
+
+    it do
+      is_expected.to validate_inclusion_of(:abura).
+        in_array(["small", "normal", "large", "mashimashi", "crazy"])
+    end
+
+    it do
+      is_expected.to validate_inclusion_of(:karame).
+        in_array(["small", "normal", "large", "mashimashi"])
+    end
+  end
+end

--- a/spec/requests/api/activities/create_spec.rb
+++ b/spec/requests/api/activities/create_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "GET /api/activities" do
+  subject do
+    post "/api/activities", params: params
+  end
+
+  let(:user) { create(:user) }
+  let(:store) { create(:store) }
+  let(:menu) { create(:menu) }
+
+  context "正常系" do
+    let(:params) {
+      {
+        storeId: store.id,
+        menuId: menu.id,
+        size: "small",
+        yasai: "small",
+        ninniku: "small",
+        abura: "small",
+        karame: "small",
+        calorie: 1234,
+        imageUrl: "http://example.com/1234.jpeg",
+      }
+    }
+
+    before do
+      stub_login(user)
+    end
+
+    it "200 okを返すこと" do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "Activityが1件増えること" do
+      expect {
+        subject
+      }.to change(Activity, :count).by(1)
+    end
+
+    it "リクエストに応じたActivityが作成されること" do
+      subject
+
+      activity = Activity.last
+
+      expect(activity.store_id).to eq(params[:storeId])
+      expect(activity.menu_id).to eq(params[:menuId])
+      expect(activity.size).to eq(params[:size])
+      expect(activity.yasai).to eq(params[:yasai])
+      expect(activity.ninniku).to eq(params[:ninniku])
+      expect(activity.abura).to eq(params[:abura])
+      expect(activity.karame).to eq(params[:karame])
+      expect(activity.calorie).to eq(params[:calorie])
+      expect(activity.image_url).to eq(params[:imageUrl])
+    end
+
+    it "作成されたActivityがレスポンスとして返ってくること" do
+      subject
+
+      activity = Activity.last
+      json = JSON.parse(response.body)
+
+      expect(json["id"]).to eq(activity.id)
+
+      expect(json["id"].present?).to eq(true)
+      expect(json["size"].present?).to eq(true)
+      expect(json["yasai"].present?).to eq(true)
+      expect(json["ninniku"].present?).to eq(true)
+      expect(json["abura"].present?).to eq(true)
+      expect(json["karame"].present?).to eq(true)
+      expect(json["store_name"].present?).to eq(true)
+      expect(json["menu_name"].present?).to eq(true)
+      expect(json["created_at"].present?).to eq(true)
+      expect(json["updated_at"].present?).to eq(true)
+    end
+  end
+
+  context "ログインしていない場合" do
+    let(:params) {
+      {
+        storeId: store.id,
+        menuId: menu.id,
+        size: "small",
+        yasai: "small",
+        ninniku: "small",
+        abura: "small",
+        karame: "small",
+        calorie: 1234,
+        imageUrl: "http://example.com/1234.jpeg",
+      }
+    }
+
+    it "401を返すこと" do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "不正なパラメタの場合" do
+    let(:params) {
+      {
+        storeId: store.id,
+        menuId: menu.id,
+        size: "",
+        yasai: "small",
+        ninniku: "small",
+        abura: "small",
+        karame: "small",
+        calorie: 1234,
+        imageUrl: "http://example.com/1234.jpeg",
+      }
+    }
+
+    before do
+      stub_login(user)
+    end
+
+    it "422を返すこと" do
+      subject
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/api/activities/create_spec.rb
+++ b/spec/requests/api/activities/create_spec.rb
@@ -71,10 +71,10 @@ describe "GET /api/activities" do
       expect(json["ninniku"].present?).to eq(true)
       expect(json["abura"].present?).to eq(true)
       expect(json["karame"].present?).to eq(true)
-      expect(json["store_name"].present?).to eq(true)
-      expect(json["menu_name"].present?).to eq(true)
-      expect(json["created_at"].present?).to eq(true)
-      expect(json["updated_at"].present?).to eq(true)
+      expect(json["storeName"].present?).to eq(true)
+      expect(json["menuName"].present?).to eq(true)
+      expect(json["createdAt"].present?).to eq(true)
+      expect(json["updatedAt"].present?).to eq(true)
     end
   end
 

--- a/spec/requests/api/activities/index_spec.rb
+++ b/spec/requests/api/activities/index_spec.rb
@@ -50,16 +50,16 @@ describe "GET /api/activities" do
       expect(res.map { |r| r["karame"] }).to match_array(
         activities.map { |a| a.karame }
       )
-      expect(res.map { |r| r["created_at"] }).to match_array(
+      expect(res.map { |r| r["createdAt"] }).to match_array(
         activities.map { |a| a.created_at }
       )
-      expect(res.map { |r| r["updated_at"] }).to match_array(
+      expect(res.map { |r| r["updatedAt"] }).to match_array(
         activities.map { |a| a.updated_at }
       )
-      expect(res.map { |r| r["store_name"] }).to match_array(
+      expect(res.map { |r| r["storeName"] }).to match_array(
         (0..4).map { |_| store.name }
       )
-      expect(res.map { |r| r["menu_name"] }).to match_array(
+      expect(res.map { |r| r["menuName"] }).to match_array(
         (0..4).map { |_| menu.name }
       )
     end

--- a/spec/requests/api/activities/index_spec.rb
+++ b/spec/requests/api/activities/index_spec.rb
@@ -32,16 +32,36 @@ describe "GET /api/activities" do
       res = JSON.parse(response.body)
 
       expect(res.size).to eq(5)
-      expect(res.map { |r| r["id"] }).to match_array(activities.map { |a| a.id })
-      expect(res.map { |r| r["size"] }).to match_array(activities.map { |a| a.size })
-      expect(res.map { |r| r["yasai"] }).to match_array(activities.map { |a| a.yasai })
-      expect(res.map { |r| r["ninniku"] }).to match_array(activities.map { |a| a.ninniku })
-      expect(res.map { |r| r["abura"] }).to match_array(activities.map { |a| a.abura })
-      expect(res.map { |r| r["karame"] }).to match_array(activities.map { |a| a.karame })
-      expect(res.map { |r| r["created_at"] }).to match_array(activities.map { |a| a.created_at })
-      expect(res.map { |r| r["updated_at"] }).to match_array(activities.map { |a| a.updated_at })
-      expect(res.map { |r| r["store_name"] }).to match_array((0..4).map { |_| store.name })
-      expect(res.map { |r| r["menu_name"] }).to match_array((0..4).map { |_| menu.name })
+      expect(res.map { |r| r["id"] }).to match_array(
+        activities.map { |a| a.id }
+      )
+      expect(res.map { |r| r["size"] }).to match_array(
+        activities.map { |a| a.size }
+      )
+      expect(res.map { |r| r["yasai"] }).to match_array(
+        activities.map { |a| a.yasai }
+      )
+      expect(res.map { |r| r["ninniku"] }).to match_array(
+        activities.map { |a| a.ninniku }
+      )
+      expect(res.map { |r| r["abura"] }).to match_array(
+        activities.map { |a| a.abura }
+      )
+      expect(res.map { |r| r["karame"] }).to match_array(
+        activities.map { |a| a.karame }
+      )
+      expect(res.map { |r| r["created_at"] }).to match_array(
+        activities.map { |a| a.created_at }
+      )
+      expect(res.map { |r| r["updated_at"] }).to match_array(
+        activities.map { |a| a.updated_at }
+      )
+      expect(res.map { |r| r["store_name"] }).to match_array(
+        (0..4).map { |_| store.name }
+      )
+      expect(res.map { |r| r["menu_name"] }).to match_array(
+        (0..4).map { |_| menu.name }
+      )
     end
   end
 

--- a/src/components/organisms/ActivityListPanel/index.vue
+++ b/src/components/organisms/ActivityListPanel/index.vue
@@ -14,9 +14,9 @@
         </thead>
         <tbody>
           <tr v-for="activity in activities" :key="activity.id">
-            <td>{{ activity.created_at | formatDate }}</td>
-            <td>{{ activity.store_name }}</td>
-            <td>{{ activity.menu_name }}</td>
+            <td>{{ activity.createdAt | formatDate }}</td>
+            <td>{{ activity.storeName }}</td>
+            <td>{{ activity.menuName }}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 内容
- Activityの新規作成APIを実装
  - 現在ログイン中のユーザーのデータが作成される

## インターフェース
```
■ Request
POST /api/activities
body {
    storeId: <integer>,
    menuId: <integer>,
    size: <string>,
    yasai: <string>,
    ninniku: <string>,
    abura: <string>,
    karame: <string>,
    calorie: <integer>,
    imageUrl: <string>,
}

■ Response
// 作成されたActivityを返す
{
    "id": <integer>,
    "size": <string>,
    "yasai": <string>,
    "ninniku": <string>,
    "abura": <string>,
    "karame": <string>,
    "storeName": <string>,
    "menuName": <string>,
    "createdAt": <datetime>,
    "updatedAt": <datetime>,
}
```