### PR TITLE
Activityフォームを開くボタンを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,9 +131,6 @@ tags
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
-
 # Thumbnails
 ._*
 

--- a/app/views/layouts/spa_page.html.erb
+++ b/app/views/layouts/spa_page.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= javascript_include_tag 'application' %>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
   </head>
 

--- a/src/components/atoms/AddActivityButton/index.vue
+++ b/src/components/atoms/AddActivityButton/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <button :type="type" class="add-activity-button" @click="onClick">
+    <Icon>edit</Icon>
+  </button>
+</template>
+
+<script>
+import Icon from '@/components/atoms/Icon';
+
+export default {
+  name: 'AddActivityButton',
+  components: {
+    Icon,
+  },
+  props: {
+    type: {
+      type: String,
+      default: 'button',
+    },
+    onClick: {
+      type: Function,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '@/components/styles/_colors.scss';
+
+.add-activity-button {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  height: 64px;
+  width: 64px;
+  color: $white;
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 50%;
+  background-color: $red;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: 0 2px 2px 0 $black10, 0 3px 1px -2px $black10,
+    0 1px 5px 0 $black10;
+
+  .material-icons {
+    font-size: 32px;
+    line-height: 36px;
+  }
+}
+</style>

--- a/src/components/atoms/Icon/index.vue
+++ b/src/components/atoms/Icon/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <i class="material-icons">
+    <slot />
+  </i>
+</template>
+
+<script>
+export default {
+  name: 'Icon',
+};
+</script>

--- a/src/components/pages/DashboardPage/index.vue
+++ b/src/components/pages/DashboardPage/index.vue
@@ -6,9 +6,6 @@
       <div v-else>
         <ActivityListPanel :activities="activities" />
       </div>
-      <button type="button" @click="openModal">
-        モーダルを開く
-      </button>
       <Modal v-if="isOpenModal">
         <ActivityFormPanel
           :activity-params="activityParams"
@@ -16,6 +13,7 @@
           :on-close="closeModal"
         />
       </Modal>
+      <AddActivityButton :on-click="openModal" />
     </div>
   </HeaderLayout>
 </template>
@@ -29,6 +27,7 @@ import ActivityFormPanel from '@/components/organisms/ActivityFormPanel';
 import ErrorPage from '@/components/organisms/ErrorPage';
 import Loading from '@/components/molecules/Loading';
 import Modal from '@/components/atoms/Modal';
+import AddActivityButton from '@/components/atoms/AddActivityButton';
 
 export default {
   name: 'DashboardPage',
@@ -39,6 +38,7 @@ export default {
     ErrorPage,
     Loading,
     Modal,
+    AddActivityButton,
   },
   data() {
     return {


### PR DESCRIPTION
## やったこと
- Activityフォームのモーダルを開くボタンを追加

![スクリーンショット 2019-07-07 23 25 28](https://user-images.githubusercontent.com/24544727/60769736-85ec9800-a10e-11e9-8dab-d34800cab7ca.png)

- 上述のボタンの実装に関して、googleのMaterialIconsを利用できるようにした
  - MaterialIconsを使用する場合は、`atoms/Icon`コンポーネント経由で利用すること 


