### PR TITLE
IOS/safariでのデザイン修正

### DIFF
--- a/src/components/atoms/AddActivityButton/index.vue
+++ b/src/components/atoms/AddActivityButton/index.vue
@@ -38,6 +38,7 @@ export default {
   font-size: 16px;
   font-weight: bold;
   border-radius: 50%;
+  border: 1px solid $red;
   background-color: $red;
   text-align: center;
   text-decoration: none;

--- a/src/components/atoms/Button/index.vue
+++ b/src/components/atoms/Button/index.vue
@@ -36,6 +36,9 @@ export default {
         case 'primary': {
           return 'button__primary';
         }
+        case 'bordered': {
+          return 'button__bordered';
+        }
         default:
           return 'button';
       }
@@ -82,6 +85,29 @@ export default {
   &:disabled {
     background-color: $yello-thin;
     border: 1px solid $yello-thin;
+  }
+}
+
+.button__bordered {
+  @extend .button;
+
+  background-color: transparent;
+  border: 1px solid $yellow;
+
+  &:hover {
+    background-color: $yellow;
+    border: 1px solid $yellow;
+  }
+
+  &:active {
+    background-color: $yellow;
+    border: 1px solid $yellow;
+  }
+
+  &:disabled {
+    color: $black40;
+    background-color: $black40;
+    border: 1px solid $black40;
   }
 }
 </style>

--- a/src/components/molecules/SelectField/index.vue
+++ b/src/components/molecules/SelectField/index.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="select-field">
+    <Icon>keyboard_arrow_down</Icon>
     <select @focus="onFocus" @change="onChange">
-      <option value.value="" />
+      <option value.value="">
+        ---
+      </option>
       <option v-for="option in options" :key="option.id" :value="option.value">
         {{ option.label }}
       </option>
@@ -13,8 +16,13 @@
 </template>
 
 <script>
+import Icon from '@/components/atoms/Icon';
+
 export default {
   name: 'SelectField',
+  components: {
+    Icon,
+  },
   props: {
     options: {
       type: Array,
@@ -66,6 +74,14 @@ export default {
 
 .select-field {
   width: 100%;
+  position: relative;
+
+  .material-icons {
+    position: absolute;
+    top: 6px;
+    right: calc(50%);
+    color: $black40;
+  }
 }
 
 select {
@@ -75,7 +91,7 @@ select {
   -webkit-appearance: none;
   margin-bottom: 2px;
   cursor: pointer;
-  width: 100%;
+  width: 50%;
 }
 
 .error-label {

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -102,7 +102,7 @@
 
         <div class="activity-form--footer">
           <ButtonGroup>
-            <Button type="button" :on-click="onClose">
+            <Button type="button" button-style="bordered" :on-click="onClose">
               戻る
             </Button>
             <Button

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -7,123 +7,114 @@
 
       <form @submit.prevent>
         <div class="activity-form--body">
-          <table>
-            <tbody>
-              <tr>
-                <td style="width: 40%;">
-                  店名
-                </td>
-                <td>
-                  <SelectField
-                    v-model="storeId"
-                    label="店名を選択"
-                    error-label="店名を選択をしてください"
-                    :validate="validateStoreId"
-                    :options="activityParams.store"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  メニュー
-                </td>
-                <td>
-                  <SelectField
-                    v-model="menuId"
-                    label="メニューを選択"
-                    error-label="メニューを選択をしてください"
-                    :validate="validateMenuId"
-                    :options="activityParams.menu"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  麺の量
-                </td>
-                <td>
-                  <SelectField
-                    v-model="size"
-                    label="麺の量を選択"
-                    error-label="麺の量を選択してください"
-                    :validate="validateSize"
-                    :options="activityParams.size"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  野菜の量
-                </td>
-                <td>
-                  <SelectField
-                    v-model="yasai"
-                    label="野菜の量を選択"
-                    error-label="野菜の量を選択してください"
-                    :validate="validateYasai"
-                    :options="activityParams.yasai"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  アブラの量
-                </td>
-                <td>
-                  <SelectField
-                    v-model="abura"
-                    label="アブラの量を選択"
-                    error-label="アブラの量を選択してください"
-                    :validate="validateAbura"
-                    :options="activityParams.abura"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  にんにくの量
-                </td>
-                <td>
-                  <SelectField
-                    v-model="ninniku"
-                    label="にんにくの量を選択"
-                    error-label="にんにくの量を選択してください"
-                    :validate="validateNinniku"
-                    :options="activityParams.ninniku"
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td style="width: 40%;">
-                  カラシの量
-                </td>
-                <td>
-                  <SelectField
-                    v-model="karame"
-                    label="カラシの量を選択"
-                    error-label="カラシの量を選択してください"
-                    :validate="validateKarame"
-                    :options="activityParams.karame"
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="form--field-group">
+            <div class="form--field-label">
+              店名
+            </div>
+            <SelectField
+              v-model="storeId"
+              label="店名を選択"
+              error-label="店名を選択をしてください"
+              :validate="validateStoreId"
+              :options="activityParams.store"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              メニュー
+            </div>
+            <SelectField
+              v-model="menuId"
+              label="メニューを選択"
+              error-label="メニューを選択をしてください"
+              :validate="validateMenuId"
+              :options="activityParams.menu"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              麺の量
+            </div>
+            <SelectField
+              v-model="size"
+              label="麺の量を選択"
+              error-label="麺の量を選択してください"
+              :validate="validateSize"
+              :options="activityParams.size"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              野菜の量
+            </div>
+            <SelectField
+              v-model="yasai"
+              label="野菜の量を選択"
+              error-label="野菜の量を選択してください"
+              :validate="validateYasai"
+              :options="activityParams.yasai"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              アブラの量
+            </div>
+            <SelectField
+              v-model="abura"
+              label="アブラの量を選択"
+              error-label="アブラの量を選択してください"
+              :validate="validateAbura"
+              :options="activityParams.abura"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              にんにくの量
+            </div>
+
+            <SelectField
+              v-model="ninniku"
+              label="にんにくの量を選択"
+              error-label="にんにくの量を選択してください"
+              :validate="validateNinniku"
+              :options="activityParams.ninniku"
+            />
+          </div>
+
+          <div class="form--field-group">
+            <div class="form--field-label">
+              カラシの量
+            </div>
+            <SelectField
+              v-model="karame"
+              label="カラシの量を選択"
+              error-label="カラシの量を選択してください"
+              :validate="validateKarame"
+              :options="activityParams.karame"
+            />
+          </div>
         </div>
 
-        <ButtonGroup>
-          <Button type="button" :on-click="onClose">
-            戻る
-          </Button>
-          <Button
-            type="submit"
-            button-style="primary"
-            :disabled="!validateForm() || isLoading"
-            :on-click="handleSubmit"
-          >
-            {{ isLoading ? '送信中...' : '作成する' }}
-          </Button>
-        </ButtonGroup>
+        <div class="activity-form--footer">
+          <ButtonGroup>
+            <Button type="button" :on-click="onClose">
+              戻る
+            </Button>
+            <Button
+              type="submit"
+              button-style="primary"
+              :disabled="!validateForm() || isLoading"
+              :on-click="handleSubmit"
+            >
+              {{ isLoading ? '送信中...' : '作成する' }}
+            </Button>
+          </ButtonGroup>
+        </div>
       </form>
     </div>
   </Panel>
@@ -251,24 +242,32 @@ export default {
 <style lang="scss" scoped>
 @import '@/components/styles/_colors.scss';
 @import '@/components/styles/_form.scss';
-@import '@/components/styles/_table.scss';
 
 .activity-form {
-  padding: 24px 16px;
-  height: 612px;
-  max-height: calc(100vh - 80px);
-  overflow-y: scroll;
+  min-height: calc(100vh - 144px);
+
+  form {
+    height: 100%;
+  }
 
   &--header {
+    padding: 16px;
     font-size: 16px;
     font-weight: bold;
     color: $black60;
-    padding-left: 16px;
-    margin-bottom: 24px;
+    height: 24px;
+    border-bottom: 1px solid $black5;
   }
 
   &--body {
-    margin-bottom: 32px;
+    padding: 16px;
+    height: calc(100vh - 300px);
+    overflow-y: scroll;
+  }
+
+  &--footer {
+    box-shadow: 0 0 4px $black10;
+    padding: 16px;
   }
 }
 </style>

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -268,6 +268,7 @@ export default {
   &--footer {
     box-shadow: 0 0 4px $black10;
     padding: 16px;
+    background-color: $black1;
   }
 }
 </style>

--- a/src/components/styles/_colors.scss
+++ b/src/components/styles/_colors.scss
@@ -11,3 +11,4 @@ $black40: #828282;
 $black20: #bdbdbd;
 $black10: #e0e0e0;
 $black5: #f1f1f1;
+$black1: #fefefe;

--- a/src/components/styles/_form.scss
+++ b/src/components/styles/_form.scss
@@ -1,21 +1,15 @@
 @import '@/components/styles/_colors.scss';
 
 form {
-  .field-group__horizonal {
+  .form--field-group {
     width: 100%;
-    display: flex;
-    padding-top: 20px;
-    padding-bottom: 24px;
+    margin-bottom: 24px;
+  }
 
-    .field-label {
-      font-size: 14px;
-      font-weight: bold;
-      color: $black60;
-      margin-top: 8px;
-      margin-right: 16px;
-      width: 140px;
-    }
-
-    border-bottom: 1px solid $black5;
+  .form--field-label {
+    font-size: 14px;
+    font-weight: bold;
+    color: $black60;
+    margin-bottom: 8px;
   }
 }


### PR DESCRIPTION
## やったこと
- IOS/safariでのデザイン修正
- 主にフォームのデザインを修正
  - ios/safariではselect選択時にズームが行われるため、入力項目のラベル名が見えなくなってしまった
  - そのため、ラベル名/select項目を縦並びになるようにした
  - 一方で縦長になるので、フォームのヘッダー/フッターを固定表示にし、送信ボタンでファーストビューで見えるようにした

## スクリーンショット
- フォームのデザイン
<img width="380" alt="スクリーンショット 2019-07-15 9 33 57" src="https://user-images.githubusercontent.com/24544727/61191298-b2427e80-a6e3-11e9-8a32-2ecdcbf5ef9d.png">

- select選択時
<img width="396" alt="スクリーンショット 2019-07-15 9 34 19" src="https://user-images.githubusercontent.com/24544727/61191302-bc647d00-a6e3-11e9-9030-ec64a4982772.png">
