### PR TITLE
フラッシュメッセージを表示するようにした

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,12 +1,19 @@
 <template>
   <div>
-    <router-view />
+    <FlashProvider>
+      <router-view />
+    </FlashProvider>
   </div>
 </template>
 
 <script>
+import FlashProvider from '@/components/providers/FlashProvider';
+
 export default {
   name: 'App',
+  components: {
+    FlashProvider,
+  },
 };
 </script>
 

--- a/src/components/molecules/FlashMessage/index.vue
+++ b/src/components/molecules/FlashMessage/index.vue
@@ -1,0 +1,52 @@
+<template>
+  <div v-if="isActive" class="flash-message">
+    <div>{{ message }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FlashMessage',
+  props: {
+    isActive: {
+      type: Boolean,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '@/components/styles/_colors.scss';
+
+.flash-message {
+  position: fixed;
+  left: 32px;
+  bottom: 24px;
+  display: flex;
+  background-color: $yellow-pale;
+  color: $black60;
+  line-height: 24px;
+  padding: 8px 16px;
+  box-shadow: 0 1px 2px $black80;
+  border-radius: 2px;
+  z-index: 100;
+  animation: slide-up 0.5s;
+}
+
+@keyframes slide-up {
+  0% {
+    opacity: 0;
+    transform: translateX(-2%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0%);
+  }
+}
+</style>

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -2,7 +2,7 @@
   <Panel style="width: 100%;">
     <div class="activity-form">
       <div class="activity-form--header">
-        食事履歴を作成する
+        食事記録を作成する
       </div>
 
       <form @submit.prevent>
@@ -234,7 +234,7 @@ export default {
           this.karame.value
         );
         this.finishLoding();
-        this.useFlash('食事履歴を作成しました！');
+        this.useFlash('食事記録を作成しました！');
       }
     },
   },

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -2,7 +2,7 @@
   <Panel style="width: 100%;">
     <div class="activity-form">
       <div class="activity-form--header">
-        活動記録を作成する
+        食事履歴を作成する
       </div>
 
       <form @submit.prevent>
@@ -128,6 +128,7 @@ import ButtonGroup from '@/components/molecules/ButtonGroup';
 
 export default {
   name: 'ActivityFormPanel',
+  inject: ['useFlash'],
   components: {
     Panel,
     SelectField,
@@ -233,6 +234,7 @@ export default {
           this.karame.value
         );
         this.finishLoding();
+        this.useFlash('食事履歴を作成しました！');
       }
     },
   },

--- a/src/components/organisms/ActivityListPanel/index.vue
+++ b/src/components/organisms/ActivityListPanel/index.vue
@@ -1,7 +1,7 @@
 <template>
   <Panel class="activity-list-panel">
     <div class="activity-list-panel--header">
-      最新の食事履歴
+      最新の食事記録
     </div>
     <div v-if="activities.length">
       <table>

--- a/src/components/providers/FlashProvider/index.vue
+++ b/src/components/providers/FlashProvider/index.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <slot />
+    <FlashMessage :is-active="isActive" :message="message" />
+  </div>
+</template>
+
+<script>
+import FlashMessage from '@/components/molecules/FlashMessage';
+
+export default {
+  name: 'FlashProvider',
+  components: {
+    FlashMessage,
+  },
+  data() {
+    return {
+      isActive: false,
+      message: '',
+    };
+  },
+  methods: {
+    useFalsh(message) {
+      this.isActive = true;
+      this.message = message;
+
+      setTimeout(() => {
+        this.isActive = false;
+        this.message = '';
+      }, 3000);
+    },
+  },
+  provide() {
+    return {
+      useFlash: this.useFalsh,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
## やったこと
- タイトル通り
- 食事記録を作成した後にフラッシュメッセージを表示することで、正しく作成されることをユーザーにフィッドバックを与えるようにした

## MEMO
- フラッシュメッセージは、Vue.jsの`provide / inject`の機能を使って実装している
  - `provide / inject`は親<->孫コンポーネントのように、離れたコンポーネント間の通信で使われる方法
  - しかし、`provide / inject`はドキュメントの記載にあるように、本来単一方向であるべきであるコンポーネント間の依存関係を複雑にする方法であるため、利用は推奨されていない
  - おそらく通常のフラッシュメッセージの実装は、vuexを使った単一データストアを利用するのがベターであるが、今回はvuexを利用していないため`project/inject`を利用した
  - ドキュメント -> https://jp.vuejs.org/v2/api/index.html#provide-inject

## スクリーンショット
<img width="508" alt="スクリーンショット 2019-07-15 9 55 13" src="https://user-images.githubusercontent.com/24544727/61191523-a906e100-a6e6-11e9-93e5-8e06f9100dd3.png">

