### PR TITLE
ユーザービリティの観点からUIデザインを修正

### DIFF
--- a/src/components/atoms/Button/index.vue
+++ b/src/components/atoms/Button/index.vue
@@ -53,7 +53,7 @@ export default {
 .button {
   color: $black60;
   font-weight: bold;
-  font-size: 14px;
+  font-size: 16px;
   padding: 6px 10px;
   border-radius: 4px;
   border: 1px solid transparent;

--- a/src/components/molecules/FlashMessage/index.vue
+++ b/src/components/molecules/FlashMessage/index.vue
@@ -26,7 +26,7 @@ export default {
 .flash-message {
   position: fixed;
   left: 32px;
-  bottom: 24px;
+  bottom: 32px;
   display: flex;
   background-color: $yellow-pale;
   color: $black60;

--- a/src/components/molecules/SelectField/index.vue
+++ b/src/components/molecules/SelectField/index.vue
@@ -92,6 +92,11 @@ select {
   margin-bottom: 2px;
   cursor: pointer;
   width: 50%;
+  outline: 0;
+
+  &:focus {
+    border: 1px solid red;
+  }
 }
 
 .error-label {

--- a/src/components/molecules/SelectField/index.vue
+++ b/src/components/molecules/SelectField/index.vue
@@ -85,7 +85,7 @@ export default {
 }
 
 select {
-  font-size: 12px;
+  font-size: 16px;
   padding: 8px 12px;
   border: 1px solid $black10;
   -webkit-appearance: none;
@@ -95,12 +95,12 @@ select {
 }
 
 .error-label {
-  font-size: 12px;
+  font-size: 16px;
   color: $red;
 }
 
 .label {
-  font-size: 12px;
+  font-size: 16px;
   color: $black60;
 }
 </style>

--- a/src/components/organisms/ActivityFormPanel/index.vue
+++ b/src/components/organisms/ActivityFormPanel/index.vue
@@ -128,7 +128,6 @@ import ButtonGroup from '@/components/molecules/ButtonGroup';
 
 export default {
   name: 'ActivityFormPanel',
-  inject: ['useFlash'],
   components: {
     Panel,
     SelectField,
@@ -234,7 +233,6 @@ export default {
           this.karame.value
         );
         this.finishLoding();
-        this.useFlash('食事記録を作成しました！');
       }
     },
   },

--- a/src/components/organisms/ActivityListPanel/index.vue
+++ b/src/components/organisms/ActivityListPanel/index.vue
@@ -59,15 +59,15 @@ export default {
   margin-bottom: 80px;
 
   &--header {
+    font-size: 16px;
     padding: 16px;
-    font-size: 14px;
     color: $black80;
     font-weight: bold;
   }
 
   &--no-activity {
     padding: 0 24px 24px 24px;
-    font-size: 14px;
+    font-size: 16px;
     color: $black80;
   }
 }

--- a/src/components/pages/DashboardPage/index.vue
+++ b/src/components/pages/DashboardPage/index.vue
@@ -86,6 +86,7 @@ export default {
         const activites = await getActivites();
         this.activities = activites;
         this.closeModal();
+        window.scrollTo(0, 0);
         this.useFlash('食事記録を作成しました！');
       } catch {
         // eslint-disable-next-line no-alert

--- a/src/components/pages/DashboardPage/index.vue
+++ b/src/components/pages/DashboardPage/index.vue
@@ -40,6 +40,7 @@ export default {
     Modal,
     AddActivityButton,
   },
+  inject: ['useFlash'],
   data() {
     return {
       activities: [],
@@ -85,6 +86,7 @@ export default {
         const activites = await getActivites();
         this.activities = activites;
         this.closeModal();
+        this.useFlash('食事記録を作成しました！');
       } catch {
         // eslint-disable-next-line no-alert
         alert(

--- a/src/components/styles/_form.scss
+++ b/src/components/styles/_form.scss
@@ -7,7 +7,7 @@ form {
   }
 
   .form--field-label {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: bold;
     color: $black60;
     margin-bottom: 8px;

--- a/src/components/styles/_table.scss
+++ b/src/components/styles/_table.scss
@@ -2,7 +2,7 @@
 
 table {
   width: 100%;
-  font-size: 14px;
+  font-size: 16px;
   border-collapse: collapse;
   box-sizing: border-box;
   text-align: left;


### PR DESCRIPTION
## やったこと
- font-sizeを16px以上にした
  - 以下記事にあるとおり、ios/safariでは、font-sizeが16pxより小さい場合に、inputやselect要素にフォーカスが当たった場合にズームが発生する
  - 今回のフォームでは16pxより小さい文字があり、これはユーザービリティの観点から良くないと判断し、font-sizeを大きくした
  - https://qiita.com/skwbr/items/b285cc312587c73a4812
- selectのfocusを指定
  - ios/safariでは、selectのfocusは明示的に指定しないと効かない
  - focusが視覚的わからないUIは、ユーザービリティの観点から良くないと判断して修正
- 食事記録作成後に、スクロール位置をトップへ移動
  - 作成された食事記録は一覧をトップに表示されるが、スクロール位置がトップになければ、作成された記録がどこにあるかわからない
  - これはユーザービリティの観点から良くないと判断し、スクロール位置がトップへ移動するように修正

## スクリーンショット
- フォームのデザイン
<img width="508" alt="スクリーンショット 2019-07-15 11 23 58" src="https://user-images.githubusercontent.com/24544727/61192970-1caeeb00-a6f3-11e9-91c0-df8bc4e59b29.png">

- select要素をfocus時
<img width="508" alt="スクリーンショット 2019-07-15 11 24 02" src="https://user-images.githubusercontent.com/24544727/61192980-2f292480-a6f3-11e9-93a2-a957a0c196b5.png">

- 食事記録作成後の一覧画面
<img width="508" alt="スクリーンショット 2019-07-15 11 24 19" src="https://user-images.githubusercontent.com/24544727/61192987-3a7c5000-a6f3-11e9-8738-85ede8ea235e.png">


